### PR TITLE
Method not allowed

### DIFF
--- a/src/main/java/httpServer/HttpServer.java
+++ b/src/main/java/httpServer/HttpServer.java
@@ -2,7 +2,7 @@ package httpServer;
 import httpServer.http.HTTPMethods;
 import httpServer.outputManagement.ClientWriteableFactory;
 import httpServer.outputManagement.ClientWriterFactory;
-import httpServer.http.ResponseBuilder;
+import httpServer.http.HTTPResponseWriter;
 
 import httpServer.routes.Router;
 import httpServer.socketManagement.ServerSocketInterface;
@@ -16,7 +16,7 @@ import java.util.Map;
 public class HttpServer {
 
     public static void main(String[] args) throws IOException {
-        Router router = new Router(getRoutes(), new ResponseBuilder());
+        Router router = new Router(getRoutes(), new HTTPResponseWriter());
         ServerSocketInterface serverSocket = new ServerSocketWrapper();
         ClientWriteableFactory clientWriterFactory = new ClientWriterFactory();
         ClientReadableFactory clientReaderFactory = new ClientReaderFactory();

--- a/src/main/java/httpServer/HttpServer.java
+++ b/src/main/java/httpServer/HttpServer.java
@@ -2,6 +2,7 @@ package httpServer;
 import httpServer.http.HTTPMethods;
 import httpServer.outputManagement.ClientWriteableFactory;
 import httpServer.outputManagement.ClientWriterFactory;
+import httpServer.http.ResponseBuilder;
 
 import httpServer.routes.Router;
 import httpServer.socketManagement.ServerSocketInterface;
@@ -15,7 +16,7 @@ import java.util.Map;
 public class HttpServer {
 
     public static void main(String[] args) throws IOException {
-        Router router = new Router(getRoutes());
+        Router router = new Router(getRoutes(), new ResponseBuilder());
         ServerSocketInterface serverSocket = new ServerSocketWrapper();
         ClientWriteableFactory clientWriterFactory = new ClientWriterFactory();
         ClientReadableFactory clientReaderFactory = new ClientReaderFactory();

--- a/src/main/java/httpServer/ListenerAndResponder.java
+++ b/src/main/java/httpServer/ListenerAndResponder.java
@@ -2,6 +2,7 @@ package httpServer;
 
 import httpServer.http.HTTPRequest;
 import httpServer.http.RequestParser;
+import httpServer.http.ResponseBuilder;
 import httpServer.routes.Router;
 import httpServer.http.StatusCodes;
 import httpServer.outputManagement.ClientWriteableFactory;
@@ -51,9 +52,8 @@ public class ListenerAndResponder implements ListenAndRespondable {
         if (!httpRequest.equals("")) {
             HTTPRequest request = RequestParser.parse(httpRequest);
             System.out.println(httpRequest);
-            StatusCodes statusCodes = router.getResponse(request);
-            String responseText = statusCodes.httpResponse;
-            printServerResponse(responseText, printer);
+            String httpResponse = router.getResponse(request);
+            printServerResponse(httpResponse, printer);
         }
 
     }

--- a/src/main/java/httpServer/ListenerAndResponder.java
+++ b/src/main/java/httpServer/ListenerAndResponder.java
@@ -2,7 +2,6 @@ package httpServer;
 
 import httpServer.http.HTTPRequest;
 import httpServer.http.RequestParser;
-import httpServer.http.ResponseBuilder;
 import httpServer.routes.Router;
 import httpServer.http.StatusCodes;
 import httpServer.outputManagement.ClientWriteableFactory;

--- a/src/main/java/httpServer/ListenerAndResponder.java
+++ b/src/main/java/httpServer/ListenerAndResponder.java
@@ -12,6 +12,8 @@ import httpServer.socketManagement.ServerSocketInterface;
 import java.io.IOException;
 import java.net.Socket;
 
+import static httpServer.http.Constants.CRLF;
+
 public class ListenerAndResponder implements ListenAndRespondable {
     ServerSocketInterface serverSocket;
     ClientReadableFactory clientReaderFactory;
@@ -41,32 +43,31 @@ public class ListenerAndResponder implements ListenAndRespondable {
     public void readClientInput(Socket clientSocket) throws IOException {
 
         ClientReadable bufferedReader = clientReaderFactory.makeReader(clientSocket);
-        ClientWriteable printer = clientWriterFactory.makePrinter(clientSocket);
+
         String httpRequest;
         httpRequest = readAllLines(bufferedReader);
         if (httpRequest == null) {
             StatusCodes statusCodes = StatusCodes.BAD_REQUEST;
             String responseText = statusCodes.httpResponse;
-            printServerResponse(responseText, printer);
+            printServerResponse(responseText, clientSocket);
         }
         if (!httpRequest.equals("")) {
             HTTPRequest request = RequestParser.parse(httpRequest);
             System.out.println(httpRequest);
             String httpResponse = router.getResponse(request);
-            printServerResponse(httpResponse, printer);
+            printServerResponse(httpResponse, clientSocket);
         }
 
     }
 
-    private void printServerResponse(String message, ClientWriteable printer) throws IOException {
-
+    private void printServerResponse(String message, Socket clientSocket) throws IOException {
+            ClientWriteable printer = clientWriterFactory.makePrinter(clientSocket);
             System.out.println(message);
             printer.println(message);
 
     }
 
     private String readAllLines(ClientReadable bufferedReader)  {
-        String CRLF = "\r\n";
         String line;
         StringBuilder stringBuilder = new StringBuilder();
         try {

--- a/src/main/java/httpServer/http/HTTPResponse.java
+++ b/src/main/java/httpServer/http/HTTPResponse.java
@@ -1,0 +1,7 @@
+package httpServer.http;
+
+public class HTTPResponse {
+
+
+
+}

--- a/src/main/java/httpServer/http/HTTPResponse.java
+++ b/src/main/java/httpServer/http/HTTPResponse.java
@@ -13,4 +13,9 @@ public class HTTPResponse {
         this.contentLengthLine = contentLengthLine;
     }
 
+    public String getFullResponse() {
+
+        return(statusLine + allowLine + contentLengthLine);
+    }
+
 }

--- a/src/main/java/httpServer/http/HTTPResponse.java
+++ b/src/main/java/httpServer/http/HTTPResponse.java
@@ -7,7 +7,7 @@ public class HTTPResponse {
     String allowLine;
     String contentLengthLine;
 
-    public HTTPResponse(String statusLine, String allowLine, String contentLengthLine, String fullHttpResponse) {
+    public HTTPResponse(String statusLine, String allowLine, String contentLengthLine) {
         this.statusLine = statusLine;
         this.allowLine = allowLine;
         this.contentLengthLine = contentLengthLine;

--- a/src/main/java/httpServer/http/HTTPResponse.java
+++ b/src/main/java/httpServer/http/HTTPResponse.java
@@ -1,0 +1,16 @@
+package httpServer.http;
+
+
+public class HTTPResponse {
+
+    String statusLine;
+    String allowLine;
+    String contentLengthLine;
+
+    public HTTPResponse(String statusLine, String allowLine, String contentLengthLine, String fullHttpResponse) {
+        this.statusLine = statusLine;
+        this.allowLine = allowLine;
+        this.contentLengthLine = contentLengthLine;
+    }
+
+}

--- a/src/main/java/httpServer/http/HTTPResponse.java
+++ b/src/main/java/httpServer/http/HTTPResponse.java
@@ -1,7 +1,0 @@
-package httpServer.http;
-
-public class HTTPResponse {
-
-
-
-}

--- a/src/main/java/httpServer/http/HTTPResponse.java
+++ b/src/main/java/httpServer/http/HTTPResponse.java
@@ -4,18 +4,28 @@ package httpServer.http;
 public class HTTPResponse {
 
     String statusLine;
-    String allowLine;
-    String contentLengthLine;
+    String allowHeader;
+    String contentLengthHeader;
 
-    public HTTPResponse(String statusLine, String allowLine, String contentLengthLine) {
+    public HTTPResponse(String statusLine, String allowHeader, String contentLengthHeader) {
         this.statusLine = statusLine;
-        this.allowLine = allowLine;
-        this.contentLengthLine = contentLengthLine;
+        this.allowHeader = allowHeader;
+        this.contentLengthHeader = contentLengthHeader;
     }
 
     public String getFullResponse() {
+        StringBuilder fullResponse = new StringBuilder();
+        appendIfNotNull(fullResponse, statusLine);
+        appendIfNotNull(fullResponse, allowHeader);
+        appendIfNotNull(fullResponse, contentLengthHeader);
+        return fullResponse.toString();
+    }
 
-        return(statusLine + allowLine + contentLengthLine);
+    private StringBuilder appendIfNotNull(StringBuilder stringBuilder, String lineOrHeader) {
+        if (!(lineOrHeader == null)) {
+            stringBuilder.append(lineOrHeader);
+        }
+        return stringBuilder;
     }
 
 }

--- a/src/main/java/httpServer/http/HTTPResponseWriter.java
+++ b/src/main/java/httpServer/http/HTTPResponseWriter.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import static httpServer.http.Constants.CRLF;
 
-public class ResponseBuilder {
+public class HTTPResponseWriter {
 
     public String buildResponse(StatusCodes statusCode, List methods, HTTPRequest request){
         StringBuilder responseStringBuilder = new StringBuilder();

--- a/src/main/java/httpServer/http/HTTPResponseWriter.java
+++ b/src/main/java/httpServer/http/HTTPResponseWriter.java
@@ -8,15 +8,16 @@ public class HTTPResponseWriter {
 
 
     public String buildResponse(StatusCodes statusCode, List methods, HTTPRequest request){
-
-        //  HTTPResponse response = new HTTPResponse();
-        StringBuilder responseStringBuilder = new StringBuilder();
-        responseStringBuilder.append(makeStatusLine(statusCode, request));
+        String statusLine;
+        String allowHeader = null;
+        String contentLengthHeader;
+        statusLine = makeStatusLine(statusCode, request);
         if (!statusCode.equals(StatusCodes.PAGE_NOT_FOUND)) {
-            responseStringBuilder.append(makeAllowHeader(methods));
+            allowHeader = makeAllowHeader(methods);
         }
-        responseStringBuilder.append(makeContentLengthHeader(0));
-        return responseStringBuilder.toString();
+        contentLengthHeader = makeContentLengthHeader(0);
+        HTTPResponse response = new HTTPResponse(statusLine, allowHeader, contentLengthHeader);
+        return(response.getFullResponse());
     }
 
     private String makeStatusLine(StatusCodes statusCode, HTTPRequest request) {

--- a/src/main/java/httpServer/http/HTTPResponseWriter.java
+++ b/src/main/java/httpServer/http/HTTPResponseWriter.java
@@ -39,7 +39,7 @@ public class HTTPResponseWriter {
     }
 
     private String makeContentLengthHeader(int length) {
-    return("Content-Length: " + String.valueOf(length) + CRLF);
+        return("Content-Length: " + String.valueOf(length) + CRLF);
     }
 
 }

--- a/src/main/java/httpServer/http/HTTPResponseWriter.java
+++ b/src/main/java/httpServer/http/HTTPResponseWriter.java
@@ -6,14 +6,16 @@ import static httpServer.http.Constants.CRLF;
 
 public class HTTPResponseWriter {
 
+
     public String buildResponse(StatusCodes statusCode, List methods, HTTPRequest request){
 
+        //  HTTPResponse response = new HTTPResponse();
         StringBuilder responseStringBuilder = new StringBuilder();
         responseStringBuilder.append(makeStatusLine(statusCode, request));
         if (!statusCode.equals(StatusCodes.PAGE_NOT_FOUND)) {
-            responseStringBuilder.append(makeAllowLine(methods));
+            responseStringBuilder.append(makeAllowHeader(methods));
         }
-        responseStringBuilder.append(makeContentLengthLine());
+        responseStringBuilder.append(makeContentLengthHeader(0));
         return responseStringBuilder.toString();
     }
 
@@ -25,7 +27,7 @@ public class HTTPResponseWriter {
         return statusLine.toString();
     }
 
-    private String makeAllowLine(List methods) {
+    private String makeAllowHeader(List methods) {
         StringBuilder allowLine = new StringBuilder();
         allowLine.append("Allow: ");
         for (int i = 0; i < methods.size(); i++) {
@@ -39,8 +41,8 @@ public class HTTPResponseWriter {
         return allowLine.toString();
     }
 
-    private String makeContentLengthLine() {
-    return("Content-Length: 0" + CRLF);
+    private String makeContentLengthHeader(int length) {
+    return("Content-Length: " + String.valueOf(length) + CRLF);
     }
 
 }

--- a/src/main/java/httpServer/http/HTTPResponseWriter.java
+++ b/src/main/java/httpServer/http/HTTPResponseWriter.java
@@ -21,11 +21,7 @@ public class HTTPResponseWriter {
     }
 
     private String makeStatusLine(StatusCodes statusCode, HTTPRequest request) {
-        StringBuilder statusLine = new StringBuilder();
-        statusLine.append(request.httpVersionNumber + " ");
-        statusLine.append(statusCode.httpResponse);
-        statusLine.append(CRLF);
-        return statusLine.toString();
+        return (request.httpVersionNumber + " " + statusCode.httpResponse + CRLF);
     }
 
     private String makeAllowHeader(List methods) {

--- a/src/main/java/httpServer/http/HTTPResponseWriter.java
+++ b/src/main/java/httpServer/http/HTTPResponseWriter.java
@@ -7,6 +7,7 @@ import static httpServer.http.Constants.CRLF;
 public class HTTPResponseWriter {
 
     public String buildResponse(StatusCodes statusCode, List methods, HTTPRequest request){
+
         StringBuilder responseStringBuilder = new StringBuilder();
         responseStringBuilder.append(makeStatusLine(statusCode, request));
         if (!statusCode.equals(StatusCodes.PAGE_NOT_FOUND)) {

--- a/src/main/java/httpServer/http/RequestParser.java
+++ b/src/main/java/httpServer/http/RequestParser.java
@@ -10,4 +10,6 @@ public class RequestParser {
         HTTPRequest httpRequest = new HTTPRequest(requestLine[0], requestLine[1], requestLine[2]);
         return httpRequest;
     }
+
+
 }

--- a/src/main/java/httpServer/http/RequestParser.java
+++ b/src/main/java/httpServer/http/RequestParser.java
@@ -4,7 +4,7 @@ public class RequestParser {
 
     public static HTTPRequest parse(String rawRequest) {
 
-        String[] lines = rawRequest.split(constants.CRLF);
+        String[] lines = rawRequest.split(Constants.CRLF);
         String[] requestLine = lines[0].split(" ");
 
         HTTPRequest httpRequest = new HTTPRequest(requestLine[0], requestLine[1], requestLine[2]);

--- a/src/main/java/httpServer/http/ResponseBuilder.java
+++ b/src/main/java/httpServer/http/ResponseBuilder.java
@@ -2,26 +2,44 @@ package httpServer.http;
 
 import java.util.List;
 
+import static httpServer.http.Constants.CRLF;
+
 public class ResponseBuilder {
 
-    public String buildResponse(StatusCodes statusCode, List methods){
+    public String buildResponse(StatusCodes statusCode, List methods, HTTPRequest request){
         StringBuilder responseStringBuilder = new StringBuilder();
-        responseStringBuilder.append("HTTP/1.1 ");
-        responseStringBuilder.append(statusCode.httpResponse);
-        responseStringBuilder.append(Constants.CRLF);
+        responseStringBuilder.append(makeStatusLine(statusCode, request));
         if (!statusCode.equals(StatusCodes.PAGE_NOT_FOUND)) {
-            responseStringBuilder.append("Allow: ");
-            for (int i = 0; i < methods.size(); i++) {
-                responseStringBuilder.append(methods.get(i));
-                if (i < (methods.size() - 1)) {
-                    responseStringBuilder.append(", ");
-                }
-            }
-            responseStringBuilder.append(Constants.CRLF);
+            responseStringBuilder.append(makeAllowLine(methods));
         }
-        responseStringBuilder.append("Content-Length: 0");
-        responseStringBuilder.append(Constants.CRLF);
+        responseStringBuilder.append(makeContentLengthLine());
         return responseStringBuilder.toString();
+    }
+
+    private String makeStatusLine(StatusCodes statusCode, HTTPRequest request) {
+        StringBuilder statusLine = new StringBuilder();
+        statusLine.append(request.httpVersionNumber + " ");
+        statusLine.append(statusCode.httpResponse);
+        statusLine.append(CRLF);
+        return statusLine.toString();
+    }
+
+    private String makeAllowLine(List methods) {
+        StringBuilder allowLine = new StringBuilder();
+        allowLine.append("Allow: ");
+        for (int i = 0; i < methods.size(); i++) {
+            allowLine.append(methods.get(i));
+            if (i < (methods.size() - 1)) {
+                allowLine.append(", ");
+            }
+        }
+        allowLine.append(CRLF);
+
+        return allowLine.toString();
+    }
+
+    private String makeContentLengthLine() {
+    return("Content-Length: 0" + CRLF);
     }
 
 }

--- a/src/main/java/httpServer/http/ResponseBuilder.java
+++ b/src/main/java/httpServer/http/ResponseBuilder.java
@@ -1,0 +1,27 @@
+package httpServer.http;
+
+import java.util.List;
+
+public class ResponseBuilder {
+
+
+    public String buildResponse(StatusCodes statusCode, List methods){
+        StringBuilder responseStringBuilder = new StringBuilder();
+        responseStringBuilder.append(statusCode.httpResponse);
+        responseStringBuilder.append(Constants.CRLF);
+        if (!statusCode.equals(StatusCodes.PAGE_NOT_FOUND)) {
+            responseStringBuilder.append("Allow: ");
+            for (int i = 0; i < methods.size(); i++) {
+                responseStringBuilder.append(methods.get(i));
+                if (i < (methods.size() - 1)) {
+                    responseStringBuilder.append(", ");
+                }
+            }
+            responseStringBuilder.append(Constants.CRLF);
+        }
+        responseStringBuilder.append("Content-Length: 0");
+        responseStringBuilder.append(Constants.CRLF);
+        return responseStringBuilder.toString();
+    }
+
+}

--- a/src/main/java/httpServer/http/ResponseBuilder.java
+++ b/src/main/java/httpServer/http/ResponseBuilder.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 public class ResponseBuilder {
 
-
     public String buildResponse(StatusCodes statusCode, List methods){
         StringBuilder responseStringBuilder = new StringBuilder();
         responseStringBuilder.append(statusCode.httpResponse);

--- a/src/main/java/httpServer/http/ResponseBuilder.java
+++ b/src/main/java/httpServer/http/ResponseBuilder.java
@@ -6,6 +6,7 @@ public class ResponseBuilder {
 
     public String buildResponse(StatusCodes statusCode, List methods){
         StringBuilder responseStringBuilder = new StringBuilder();
+        responseStringBuilder.append("HTTP/1.1 ");
         responseStringBuilder.append(statusCode.httpResponse);
         responseStringBuilder.append(Constants.CRLF);
         if (!statusCode.equals(StatusCodes.PAGE_NOT_FOUND)) {

--- a/src/main/java/httpServer/http/StatusCodes.java
+++ b/src/main/java/httpServer/http/StatusCodes.java
@@ -1,10 +1,10 @@
 package httpServer.http;
 
 public enum StatusCodes {
-    PAGE_NOT_FOUND("HTTP/1.1 404 Not Found" + constants.CRLF + "Content-Length: 0" + constants.CRLF ),
-    BAD_REQUEST("HTTP/1.1 400 Bad Request" + constants.CRLF + "Content-Length: 0" + constants.CRLF),
-    OK("HTTP/1.1 200 OK" + constants.CRLF + "Content-Length: 0" + constants.CRLF),
-    NOT_ACCEPTABLE("HTTP/1.1 405 Not Acceptable" + constants.CRLF + "Allow: HEAD, OPTIONS" + constants.CRLF + "Content-Length: 0" + constants.CRLF);
+    PAGE_NOT_FOUND("HTTP/1.1 404 Not Found"),
+    BAD_REQUEST("HTTP/1.1 400 Bad Request"),
+    OK("HTTP/1.1 200 OK"),
+    NOT_ACCEPTABLE("HTTP/1.1 405 Not Acceptable");
 
     public final String httpResponse;
 

--- a/src/main/java/httpServer/http/StatusCodes.java
+++ b/src/main/java/httpServer/http/StatusCodes.java
@@ -1,10 +1,10 @@
 package httpServer.http;
 
 public enum StatusCodes {
-    PAGE_NOT_FOUND("HTTP/1.1 404 Not Found"),
-    BAD_REQUEST("HTTP/1.1 400 Bad Request"),
-    OK("HTTP/1.1 200 OK"),
-    NOT_ACCEPTABLE("HTTP/1.1 405 Not Acceptable");
+    PAGE_NOT_FOUND("404 Not Found"),
+    BAD_REQUEST("400 Bad Request"),
+    OK("200 OK"),
+    NOT_ACCEPTABLE("405 Not Acceptable");
 
     public final String httpResponse;
 

--- a/src/main/java/httpServer/http/StatusCodes.java
+++ b/src/main/java/httpServer/http/StatusCodes.java
@@ -3,7 +3,8 @@ package httpServer.http;
 public enum StatusCodes {
     PAGE_NOT_FOUND("HTTP/1.1 404 Not Found" + constants.CRLF + "Content-Length: 0" + constants.CRLF ),
     BAD_REQUEST("HTTP/1.1 400 Bad Request" + constants.CRLF + "Content-Length: 0" + constants.CRLF),
-    OK("HTTP/1.1 200 OK" + constants.CRLF+ "Content-Length: 0" + constants.CRLF);
+    OK("HTTP/1.1 200 OK" + constants.CRLF + "Content-Length: 0" + constants.CRLF),
+    NOT_ACCEPTABLE("HTTP/1.1 405 Not Acceptable" + constants.CRLF + "Allow: HEAD, OPTIONS" + constants.CRLF + "Content-Length: 0" + constants.CRLF);
 
     public final String httpResponse;
 

--- a/src/main/java/httpServer/http/constants.java
+++ b/src/main/java/httpServer/http/constants.java
@@ -1,6 +1,6 @@
 package httpServer.http;
 
-public class constants {
+public class Constants {
 
     public static String CRLF = "\r\n";
 

--- a/src/main/java/httpServer/routes/Router.java
+++ b/src/main/java/httpServer/routes/Router.java
@@ -22,9 +22,12 @@ public class Router {
             List asList = Arrays.asList(allowedRoutes);
 
             for (int i = 0; i < asList.size(); i++) {
-                String firstMethodAllowed = String.valueOf(asList.get(0));
-                if (request.method.equals(firstMethodAllowed)) {
+                String methodAllowed = String.valueOf(asList.get(0));
+                if (request.method.equals(methodAllowed)) {
                     return StatusCodes.OK;
+                }
+                else {
+                    return StatusCodes.NOT_ACCEPTABLE;
                 }
             }
 

--- a/src/main/java/httpServer/routes/Router.java
+++ b/src/main/java/httpServer/routes/Router.java
@@ -2,7 +2,7 @@ package httpServer.routes;
 
 import httpServer.http.HTTPMethods;
 import httpServer.http.HTTPRequest;
-import httpServer.http.ResponseBuilder;
+import httpServer.http.HTTPResponseWriter;
 import httpServer.http.StatusCodes;
 
 import java.util.Arrays;
@@ -12,9 +12,9 @@ import java.util.Map;
 public class Router {
 
     Map<String, HTTPMethods[]> routes;
-    ResponseBuilder responseBuilder;
+    HTTPResponseWriter responseBuilder;
 
-    public Router(Map routes, ResponseBuilder responseBuilder) {
+    public Router(Map routes, HTTPResponseWriter responseBuilder) {
         this.routes = routes;
         this.responseBuilder = responseBuilder;
     }

--- a/src/main/java/httpServer/routes/Router.java
+++ b/src/main/java/httpServer/routes/Router.java
@@ -26,15 +26,15 @@ public class Router {
             allowedRoutesAsList = Arrays.asList(allowedRoutes);
 
             for (int i = 0; i < allowedRoutesAsList.size(); i++) {
-                String methodAllowed = String.valueOf(allowedRoutesAsList.get(0));
+                String methodAllowed = String.valueOf(allowedRoutesAsList.get(i));
                 if (request.method.equals(methodAllowed)) {
                     return responseBuilder.buildResponse(StatusCodes.OK, allowedRoutesAsList, request);
                 }
                 else {
-                    return responseBuilder.buildResponse(StatusCodes.NOT_ACCEPTABLE, allowedRoutesAsList, request);
+                    continue;
                 }
             }
-
+            return responseBuilder.buildResponse(StatusCodes.NOT_ACCEPTABLE, allowedRoutesAsList, request);
         }
         return responseBuilder.buildResponse(StatusCodes.PAGE_NOT_FOUND, allowedRoutesAsList, request);
     }

--- a/src/main/java/httpServer/routes/Router.java
+++ b/src/main/java/httpServer/routes/Router.java
@@ -2,6 +2,7 @@ package httpServer.routes;
 
 import httpServer.http.HTTPMethods;
 import httpServer.http.HTTPRequest;
+import httpServer.http.ResponseBuilder;
 import httpServer.http.StatusCodes;
 
 import java.util.Arrays;
@@ -11,26 +12,30 @@ import java.util.Map;
 public class Router {
 
     Map<String, HTTPMethods[]> routes;
+    ResponseBuilder responseBuilder;
 
-    public Router(Map routes) {
+    public Router(Map routes, ResponseBuilder responseBuilder) {
         this.routes = routes;
+        this.responseBuilder = responseBuilder;
     }
 
-    public StatusCodes getResponse(HTTPRequest request) {
+    public String getResponse(HTTPRequest request) {
+        List asList = null;
         if (routes.containsKey(request.resource)) {
             HTTPMethods[] allowedRoutes = routes.get(request.resource);
-            List asList = Arrays.asList(allowedRoutes);
+            asList = Arrays.asList(allowedRoutes);
 
             for (int i = 0; i < asList.size(); i++) {
                 String methodAllowed = String.valueOf(asList.get(0));
                 if (request.method.equals(methodAllowed)) {
-                    return StatusCodes.OK;
+                    return responseBuilder.buildResponse(StatusCodes.OK, asList);
                 }
                 else {
-                    return StatusCodes.NOT_ACCEPTABLE;
+                    return responseBuilder.buildResponse(StatusCodes.NOT_ACCEPTABLE, asList);
                 }
             }
 
-        } return StatusCodes.PAGE_NOT_FOUND;
+        }
+        return responseBuilder.buildResponse(StatusCodes.PAGE_NOT_FOUND, asList);
     }
 }

--- a/src/main/java/httpServer/routes/Router.java
+++ b/src/main/java/httpServer/routes/Router.java
@@ -20,22 +20,22 @@ public class Router {
     }
 
     public String getResponse(HTTPRequest request) {
-        List asList = null;
+        List allowedRoutesAsList = null;
         if (routes.containsKey(request.resource)) {
             HTTPMethods[] allowedRoutes = routes.get(request.resource);
-            asList = Arrays.asList(allowedRoutes);
+            allowedRoutesAsList = Arrays.asList(allowedRoutes);
 
-            for (int i = 0; i < asList.size(); i++) {
-                String methodAllowed = String.valueOf(asList.get(0));
+            for (int i = 0; i < allowedRoutesAsList.size(); i++) {
+                String methodAllowed = String.valueOf(allowedRoutesAsList.get(0));
                 if (request.method.equals(methodAllowed)) {
-                    return responseBuilder.buildResponse(StatusCodes.OK, asList);
+                    return responseBuilder.buildResponse(StatusCodes.OK, allowedRoutesAsList);
                 }
                 else {
-                    return responseBuilder.buildResponse(StatusCodes.NOT_ACCEPTABLE, asList);
+                    return responseBuilder.buildResponse(StatusCodes.NOT_ACCEPTABLE, allowedRoutesAsList);
                 }
             }
 
         }
-        return responseBuilder.buildResponse(StatusCodes.PAGE_NOT_FOUND, asList);
+        return responseBuilder.buildResponse(StatusCodes.PAGE_NOT_FOUND, allowedRoutesAsList);
     }
 }

--- a/src/main/java/httpServer/routes/Router.java
+++ b/src/main/java/httpServer/routes/Router.java
@@ -28,14 +28,14 @@ public class Router {
             for (int i = 0; i < allowedRoutesAsList.size(); i++) {
                 String methodAllowed = String.valueOf(allowedRoutesAsList.get(0));
                 if (request.method.equals(methodAllowed)) {
-                    return responseBuilder.buildResponse(StatusCodes.OK, allowedRoutesAsList);
+                    return responseBuilder.buildResponse(StatusCodes.OK, allowedRoutesAsList, request);
                 }
                 else {
-                    return responseBuilder.buildResponse(StatusCodes.NOT_ACCEPTABLE, allowedRoutesAsList);
+                    return responseBuilder.buildResponse(StatusCodes.NOT_ACCEPTABLE, allowedRoutesAsList, request);
                 }
             }
 
         }
-        return responseBuilder.buildResponse(StatusCodes.PAGE_NOT_FOUND, allowedRoutesAsList);
+        return responseBuilder.buildResponse(StatusCodes.PAGE_NOT_FOUND, allowedRoutesAsList, request);
     }
 }

--- a/src/main/java/httpServer/routes/Router.java
+++ b/src/main/java/httpServer/routes/Router.java
@@ -20,10 +20,9 @@ public class Router {
     }
 
     public String getResponse(HTTPRequest request) {
-        List allowedRoutesAsList = null;
         if (routes.containsKey(request.resource)) {
             HTTPMethods[] allowedRoutes = routes.get(request.resource);
-            allowedRoutesAsList = Arrays.asList(allowedRoutes);
+            List allowedRoutesAsList = Arrays.asList(allowedRoutes);
 
             for (int i = 0; i < allowedRoutesAsList.size(); i++) {
                 String methodAllowed = String.valueOf(allowedRoutesAsList.get(i));
@@ -36,6 +35,6 @@ public class Router {
             }
             return responseBuilder.buildResponse(StatusCodes.NOT_ACCEPTABLE, allowedRoutesAsList, request);
         }
-        return responseBuilder.buildResponse(StatusCodes.PAGE_NOT_FOUND, allowedRoutesAsList, request);
+        return responseBuilder.buildResponse(StatusCodes.PAGE_NOT_FOUND, null, request);
     }
 }

--- a/src/test/java/httpServer/ListenerAndResponderTest.java
+++ b/src/test/java/httpServer/ListenerAndResponderTest.java
@@ -1,5 +1,6 @@
 package httpServer;
-import httpServer.http.constants;
+import httpServer.http.Constants;
+import httpServer.http.ResponseBuilder;
 import httpServer.http.StatusCodes;
 import httpServer.outputManagement.ClientWriteableFactory;
 import httpServer.routes.Router;
@@ -9,7 +10,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.Socket;
+import java.util.Map;
 
+import static httpServer.HttpServer.getRoutes;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ListenerAndResponderTest {
@@ -19,15 +22,19 @@ public class ListenerAndResponderTest {
     MockServerSocketWrapper mockServerSocket;
     MockBufferedReaderWrapper mockBufferedReader;
     MockPrintWriterWrapper mockPrintWriter;
+    ResponseBuilder responseBuilder;
+    Map routes;
 
     @BeforeEach
     void setUp() throws IOException {
-        String input = "Accept: */*" + constants.CRLF +
-                "User-Agent: jUnit" + constants.CRLF +
-                "Host: localhost:5000" + constants.CRLF +
-                "GET / HTTP/1.1" + constants.CRLF + constants.CRLF;
+        String input = "Accept: */*" + Constants.CRLF +
+                "User-Agent: jUnit" + Constants.CRLF +
+                "Host: localhost:5000" + Constants.CRLF +
+                "GET / HTTP/1.1" + Constants.CRLF + Constants.CRLF;
         socket = new Socket();
-        Router router = new Router(HttpServer.getRoutes());
+        routes = getRoutes();
+        responseBuilder = new ResponseBuilder();
+        Router router = new Router(routes, responseBuilder);
         mockServerSocket = new MockServerSocketWrapper(socket);
         mockPrintWriter =  new MockPrintWriterWrapper();
         mockBufferedReader = new MockBufferedReaderWrapper(input);
@@ -48,7 +55,7 @@ public class ListenerAndResponderTest {
 
     @Test
     void testReadClientInputCallsPrintWriterPrintLn() throws IOException {
-        String expectedResult = StatusCodes.PAGE_NOT_FOUND.httpResponse;
+        String expectedResult = StatusCodes.PAGE_NOT_FOUND.httpResponse + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
 
         echoer.readClientInput(socket);
 

--- a/src/test/java/httpServer/ListenerAndResponderTest.java
+++ b/src/test/java/httpServer/ListenerAndResponderTest.java
@@ -1,6 +1,6 @@
 package httpServer;
 import httpServer.http.Constants;
-import httpServer.http.ResponseBuilder;
+import httpServer.http.HTTPResponseWriter;
 import httpServer.http.StatusCodes;
 import httpServer.outputManagement.ClientWriteableFactory;
 import httpServer.routes.Router;
@@ -22,7 +22,7 @@ public class ListenerAndResponderTest {
     MockServerSocketWrapper mockServerSocket;
     MockBufferedReaderWrapper mockBufferedReader;
     MockPrintWriterWrapper mockPrintWriter;
-    ResponseBuilder responseBuilder;
+    HTTPResponseWriter responseBuilder;
     Map routes;
 
     @BeforeEach
@@ -33,7 +33,7 @@ public class ListenerAndResponderTest {
                 "GET / HTTP/1.1" + Constants.CRLF + Constants.CRLF;
         socket = new Socket();
         routes = getRoutes();
-        responseBuilder = new ResponseBuilder();
+        responseBuilder = new HTTPResponseWriter();
         Router router = new Router(routes, responseBuilder);
         mockServerSocket = new MockServerSocketWrapper(socket);
         mockPrintWriter =  new MockPrintWriterWrapper();

--- a/src/test/java/httpServer/ListenerAndResponderTest.java
+++ b/src/test/java/httpServer/ListenerAndResponderTest.java
@@ -55,7 +55,7 @@ public class ListenerAndResponderTest {
 
     @Test
     void testReadClientInputCallsPrintWriterPrintLn() throws IOException {
-        String expectedResult = StatusCodes.PAGE_NOT_FOUND.httpResponse + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
+        String expectedResult = "HTTP/1.1 " + StatusCodes.PAGE_NOT_FOUND.httpResponse + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
 
         echoer.readClientInput(socket);
 

--- a/src/test/java/httpServer/RequestParserTest.java
+++ b/src/test/java/httpServer/RequestParserTest.java
@@ -1,6 +1,6 @@
 package httpServer;
 
-import httpServer.http.constants;
+import httpServer.http.Constants;
 import httpServer.http.HTTPRequest;
 import httpServer.http.RequestParser;
 import org.junit.jupiter.api.Test;
@@ -16,10 +16,10 @@ public class RequestParserTest {
     void testRequestParserReturnsCorrectHTTPResponseObject() throws IOException {
 
         HTTPRequest httpRequestExpected = new HTTPRequest("GET", "/", "HTTP/1.1");
-        String request = "GET / HTTP/1.1" + constants.CRLF +
-                "Host: localhost:5000" + constants.CRLF +
-                "User-Agent: cur/7.64.1" + constants.CRLF +
-                "Accept: */*" + constants.CRLF;
+        String request = "GET / HTTP/1.1" + Constants.CRLF +
+                "Host: localhost:5000" + Constants.CRLF +
+                "User-Agent: cur/7.64.1" + Constants.CRLF +
+                "Accept: */*" + Constants.CRLF;
 
         HTTPRequest httpParsed = RequestParser.parse(request);
         assertTrue(httpParsed.equals(httpParsed));

--- a/src/test/java/httpServer/RequestParserTest.java
+++ b/src/test/java/httpServer/RequestParserTest.java
@@ -6,6 +6,7 @@ import httpServer.http.RequestParser;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,11 +19,13 @@ public class RequestParserTest {
         HTTPRequest httpRequestExpected = new HTTPRequest("GET", "/", "HTTP/1.1");
         String request = "GET / HTTP/1.1" + Constants.CRLF +
                 "Host: localhost:5000" + Constants.CRLF +
-                "User-Agent: cur/7.64.1" + Constants.CRLF +
+                "User-Agent: JUnit" + Constants.CRLF +
                 "Accept: */*" + Constants.CRLF;
 
         HTTPRequest httpParsed = RequestParser.parse(request);
-        assertTrue(httpParsed.equals(httpParsed));
+        assertEquals(httpRequestExpected.method, httpParsed.method);
+        assertEquals(httpRequestExpected.resource, httpParsed.resource);
+        assertEquals(httpRequestExpected.httpVersionNumber, httpParsed.httpVersionNumber);
 
     }
 }

--- a/src/test/java/httpServer/RouterTest.java
+++ b/src/test/java/httpServer/RouterTest.java
@@ -3,21 +3,32 @@ package httpServer;
 import httpServer.http.Constants;
 import httpServer.http.HTTPRequest;
 import httpServer.http.HTTPResponseWriter;
+import httpServer.outputManagement.ClientWriteableFactory;
 import httpServer.routes.Router;
 import httpServer.http.StatusCodes;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.Socket;
 
+import static httpServer.HttpServer.getRoutes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RouterTest {
+
+    HTTPResponseWriter responseBuilder;
+    Router router;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        responseBuilder = new HTTPResponseWriter();
+        router = new Router(HttpServer.getRoutes(), responseBuilder);
+    }
     @Test
     void testRouterReturns200ForGetRequestToSimpleGetRoute() throws IOException {
         HTTPRequest request = new HTTPRequest("GET", "/simple_get", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: GET" + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
-        HTTPResponseWriter responseBuilder = new HTTPResponseWriter();
-        Router router = new Router(HttpServer.getRoutes(), responseBuilder);
         String returnedResponse = router.getResponse(request);
         assertEquals(expectedResponse, returnedResponse);
     }
@@ -26,8 +37,6 @@ public class RouterTest {
     void testRouterReturns404ForInvalidRoute() throws IOException {
         HTTPRequest request = new HTTPRequest("GET", "/anything_invalid", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.PAGE_NOT_FOUND.httpResponse + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
-        HTTPResponseWriter responseBuilder = new HTTPResponseWriter();
-        Router router = new Router(HttpServer.getRoutes(), responseBuilder);
         String returnedResponse = router.getResponse(request);
         assertEquals(expectedResponse.toString(), returnedResponse);
     }
@@ -36,8 +45,6 @@ public class RouterTest {
     void testRouterReturns200ForValidOptionsRequest() throws IOException {
         HTTPRequest request = new HTTPRequest("OPTIONS", "/head_request", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
-        HTTPResponseWriter responseBuilder = new HTTPResponseWriter();
-        Router router = new Router(HttpServer.getRoutes(), responseBuilder);
         String returnedResponse = router.getResponse(request);
         assertEquals(expectedResponse, returnedResponse);
     }
@@ -46,8 +53,6 @@ public class RouterTest {
     void testRouterReturns200ForValidHeadRequest() throws IOException {
         HTTPRequest request = new HTTPRequest("HEAD", "/head_request", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
-        HTTPResponseWriter responseBuilder = new HTTPResponseWriter();
-        Router router = new Router(HttpServer.getRoutes(), responseBuilder);
         String returnedResponse = router.getResponse(request);
         assertEquals(expectedResponse, returnedResponse);
     }

--- a/src/test/java/httpServer/RouterTest.java
+++ b/src/test/java/httpServer/RouterTest.java
@@ -2,7 +2,7 @@ package httpServer;
 
 import httpServer.http.Constants;
 import httpServer.http.HTTPRequest;
-import httpServer.http.ResponseBuilder;
+import httpServer.http.HTTPResponseWriter;
 import httpServer.routes.Router;
 import httpServer.http.StatusCodes;
 import org.junit.jupiter.api.Test;
@@ -16,7 +16,7 @@ public class RouterTest {
     void testRouterReturns200ForGetRequestToSimpleGetRoute() throws IOException {
         HTTPRequest request = new HTTPRequest("GET", "/simple_get", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: GET" + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
-        ResponseBuilder responseBuilder = new ResponseBuilder();
+        HTTPResponseWriter responseBuilder = new HTTPResponseWriter();
         Router router = new Router(HttpServer.getRoutes(), responseBuilder);
         String returnedResponse = router.getResponse(request);
         assertEquals(expectedResponse, returnedResponse);
@@ -26,7 +26,7 @@ public class RouterTest {
     void testRouterReturns404ForInvalidRoute() throws IOException {
         HTTPRequest request = new HTTPRequest("GET", "/anything_invalid", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.PAGE_NOT_FOUND.httpResponse + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
-        ResponseBuilder responseBuilder = new ResponseBuilder();
+        HTTPResponseWriter responseBuilder = new HTTPResponseWriter();
         Router router = new Router(HttpServer.getRoutes(), responseBuilder);
         String returnedResponse = router.getResponse(request);
         assertEquals(expectedResponse.toString(), returnedResponse);
@@ -36,7 +36,7 @@ public class RouterTest {
     void testRouterReturns200ForValidOptionsRequest() throws IOException {
         HTTPRequest request = new HTTPRequest("OPTIONS", "/head_request", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
-        ResponseBuilder responseBuilder = new ResponseBuilder();
+        HTTPResponseWriter responseBuilder = new HTTPResponseWriter();
         Router router = new Router(HttpServer.getRoutes(), responseBuilder);
         String returnedResponse = router.getResponse(request);
         assertEquals(expectedResponse, returnedResponse);
@@ -46,12 +46,10 @@ public class RouterTest {
     void testRouterReturns200ForValidHeadRequest() throws IOException {
         HTTPRequest request = new HTTPRequest("HEAD", "/head_request", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
-        ResponseBuilder responseBuilder = new ResponseBuilder();
+        HTTPResponseWriter responseBuilder = new HTTPResponseWriter();
         Router router = new Router(HttpServer.getRoutes(), responseBuilder);
         String returnedResponse = router.getResponse(request);
         assertEquals(expectedResponse, returnedResponse);
     }
-
-
 
 }

--- a/src/test/java/httpServer/RouterTest.java
+++ b/src/test/java/httpServer/RouterTest.java
@@ -18,9 +18,8 @@ public class RouterTest {
         String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: GET" + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
         ResponseBuilder responseBuilder = new ResponseBuilder();
         Router router = new Router(HttpServer.getRoutes(), responseBuilder);
-        String returnedCode = router.getResponse(request);
-        System.out.print(returnedCode);
-        assertEquals(expectedResponse, returnedCode);
+        String returnedResponse = router.getResponse(request);
+        assertEquals(expectedResponse, returnedResponse);
     }
 
     @Test
@@ -29,20 +28,30 @@ public class RouterTest {
         String expectedResponse = "HTTP/1.1 " + StatusCodes.PAGE_NOT_FOUND.httpResponse + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
         ResponseBuilder responseBuilder = new ResponseBuilder();
         Router router = new Router(HttpServer.getRoutes(), responseBuilder);
-        String returnedCode = router.getResponse(request);
-        System.out.print(returnedCode);
-        assertEquals(expectedResponse.toString(), returnedCode);
+        String returnedResponse = router.getResponse(request);
+        assertEquals(expectedResponse.toString(), returnedResponse);
     }
 
     @Test
-    void testRouterReturns405ForInvalidMethod() throws IOException {
-        HTTPRequest request = new HTTPRequest("GET", "/head_request", "HTTP/1.1");
-        String expectedResponse = "HTTP/1.1 " + StatusCodes.NOT_ACCEPTABLE.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
+    void testRouterReturns200ForValidOptionsRequest() throws IOException {
+        HTTPRequest request = new HTTPRequest("OPTIONS", "/head_request", "HTTP/1.1");
+        String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
         ResponseBuilder responseBuilder = new ResponseBuilder();
         Router router = new Router(HttpServer.getRoutes(), responseBuilder);
-        String returnedCode = router.getResponse(request);
-        System.out.print(returnedCode);
-        assertEquals(expectedResponse, returnedCode);
+        String returnedResponse = router.getResponse(request);
+        assertEquals(expectedResponse, returnedResponse);
     }
+
+    @Test
+    void testRouterReturns200ForValidHeadRequest() throws IOException {
+        HTTPRequest request = new HTTPRequest("Head", "/head_request", "HTTP/1.1");
+        String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
+        ResponseBuilder responseBuilder = new ResponseBuilder();
+        Router router = new Router(HttpServer.getRoutes(), responseBuilder);
+        String returnedResponse = router.getResponse(request);
+        assertEquals(expectedResponse, returnedResponse);
+    }
+
+
 
 }

--- a/src/test/java/httpServer/RouterTest.java
+++ b/src/test/java/httpServer/RouterTest.java
@@ -42,6 +42,14 @@ public class RouterTest {
     }
 
     @Test
+    void testRouterReturns405ForInvalidMethodToExistingResource() throws IOException {
+        HTTPRequest request = new HTTPRequest("GET", "/head_request", "HTTP/1.1");
+        String expectedResponse = "HTTP/1.1 " + StatusCodes.NOT_ACCEPTABLE.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
+        String returnedResponse = router.getResponse(request);
+        assertEquals(expectedResponse, returnedResponse);
+    }
+
+    @Test
     void testRouterReturns200ForValidOptionsRequest() throws IOException {
         HTTPRequest request = new HTTPRequest("OPTIONS", "/head_request", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;

--- a/src/test/java/httpServer/RouterTest.java
+++ b/src/test/java/httpServer/RouterTest.java
@@ -30,4 +30,14 @@ public class RouterTest {
         assertEquals(expectedStatusCodes, returnedCode);
     }
 
+    @Test
+    void testRouterReturns405ForInvalidMethod() throws IOException {
+        HTTPRequest request = new HTTPRequest("GET", "/head_request", "HTTP/1.1");
+        StatusCodes expectedStatusCodes = StatusCodes.PAGE_NOT_FOUND;
+        Router router = new Router(HttpServer.getRoutes());
+        StatusCodes returnedCode = router.getResponse(request);
+        System.out.print(returnedCode);
+        assertEquals(expectedStatusCodes, returnedCode);
+    }
+
 }

--- a/src/test/java/httpServer/RouterTest.java
+++ b/src/test/java/httpServer/RouterTest.java
@@ -26,7 +26,7 @@ public class RouterTest {
         router = new Router(HttpServer.getRoutes(), responseBuilder);
     }
     @Test
-    void testRouterReturns200ForGetRequestToSimpleGetRoute() throws IOException {
+    void testRouterReturns200ForGetRequestToResourceWithGetAllowed() throws IOException {
         HTTPRequest request = new HTTPRequest("GET", "/simple_get", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: GET" + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
         String returnedResponse = router.getResponse(request);
@@ -34,7 +34,7 @@ public class RouterTest {
     }
 
     @Test
-    void testRouterReturns404ForInvalidRoute() throws IOException {
+    void testRouterReturns404ForNonExistentResource() throws IOException {
         HTTPRequest request = new HTTPRequest("GET", "/anything_invalid", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.PAGE_NOT_FOUND.httpResponse + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
         String returnedResponse = router.getResponse(request);
@@ -42,7 +42,7 @@ public class RouterTest {
     }
 
     @Test
-    void testRouterReturns405ForInvalidMethodToExistingResource() throws IOException {
+    void testRouterReturns405ForInvalidMethodRequestToExistingResource() throws IOException {
         HTTPRequest request = new HTTPRequest("GET", "/head_request", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.NOT_ACCEPTABLE.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
         String returnedResponse = router.getResponse(request);
@@ -50,7 +50,7 @@ public class RouterTest {
     }
 
     @Test
-    void testRouterReturns200ForValidOptionsRequest() throws IOException {
+    void testRouterReturns200ForFirstAllowedRequestTypeToExistingResourceWithMultipleMethods() throws IOException {
         HTTPRequest request = new HTTPRequest("OPTIONS", "/head_request", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
         String returnedResponse = router.getResponse(request);
@@ -58,7 +58,7 @@ public class RouterTest {
     }
 
     @Test
-    void testRouterReturns200ForValidHeadRequest() throws IOException {
+    void testRouterReturns200ForSecondAllowedRequestTypeToExistingResourceWithMultipleMethods() throws IOException {
         HTTPRequest request = new HTTPRequest("HEAD", "/head_request", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
         String returnedResponse = router.getResponse(request);

--- a/src/test/java/httpServer/RouterTest.java
+++ b/src/test/java/httpServer/RouterTest.java
@@ -15,34 +15,34 @@ public class RouterTest {
     @Test
     void testRouterReturns200ForGetRequestToSimpleGetRoute() throws IOException {
         HTTPRequest request = new HTTPRequest("GET", "/simple_get", "HTTP/1.1");
-        String expectedStatusCode = StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: GET" + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
+        String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: GET" + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
         ResponseBuilder responseBuilder = new ResponseBuilder();
         Router router = new Router(HttpServer.getRoutes(), responseBuilder);
         String returnedCode = router.getResponse(request);
         System.out.print(returnedCode);
-        assertEquals(expectedStatusCode, returnedCode);
+        assertEquals(expectedResponse, returnedCode);
     }
 
     @Test
     void testRouterReturns404ForInvalidRoute() throws IOException {
         HTTPRequest request = new HTTPRequest("GET", "/anything_invalid", "HTTP/1.1");
-        String expectedStatusCodes = StatusCodes.PAGE_NOT_FOUND.httpResponse + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
+        String expectedResponse = "HTTP/1.1 " + StatusCodes.PAGE_NOT_FOUND.httpResponse + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
         ResponseBuilder responseBuilder = new ResponseBuilder();
         Router router = new Router(HttpServer.getRoutes(), responseBuilder);
         String returnedCode = router.getResponse(request);
         System.out.print(returnedCode);
-        assertEquals(expectedStatusCodes.toString(), returnedCode);
+        assertEquals(expectedResponse.toString(), returnedCode);
     }
 
     @Test
     void testRouterReturns405ForInvalidMethod() throws IOException {
         HTTPRequest request = new HTTPRequest("GET", "/head_request", "HTTP/1.1");
-        String expectedStatusCodes = StatusCodes.NOT_ACCEPTABLE.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
+        String expectedResponse = "HTTP/1.1 " + StatusCodes.NOT_ACCEPTABLE.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
         ResponseBuilder responseBuilder = new ResponseBuilder();
         Router router = new Router(HttpServer.getRoutes(), responseBuilder);
         String returnedCode = router.getResponse(request);
         System.out.print(returnedCode);
-        assertEquals(expectedStatusCodes, returnedCode);
+        assertEquals(expectedResponse, returnedCode);
     }
 
 }

--- a/src/test/java/httpServer/RouterTest.java
+++ b/src/test/java/httpServer/RouterTest.java
@@ -44,7 +44,7 @@ public class RouterTest {
 
     @Test
     void testRouterReturns200ForValidHeadRequest() throws IOException {
-        HTTPRequest request = new HTTPRequest("Head", "/head_request", "HTTP/1.1");
+        HTTPRequest request = new HTTPRequest("HEAD", "/head_request", "HTTP/1.1");
         String expectedResponse = "HTTP/1.1 " + StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
         ResponseBuilder responseBuilder = new ResponseBuilder();
         Router router = new Router(HttpServer.getRoutes(), responseBuilder);

--- a/src/test/java/httpServer/RouterTest.java
+++ b/src/test/java/httpServer/RouterTest.java
@@ -1,6 +1,8 @@
 package httpServer;
 
+import httpServer.http.Constants;
 import httpServer.http.HTTPRequest;
+import httpServer.http.ResponseBuilder;
 import httpServer.routes.Router;
 import httpServer.http.StatusCodes;
 import org.junit.jupiter.api.Test;
@@ -13,29 +15,32 @@ public class RouterTest {
     @Test
     void testRouterReturns200ForGetRequestToSimpleGetRoute() throws IOException {
         HTTPRequest request = new HTTPRequest("GET", "/simple_get", "HTTP/1.1");
-        StatusCodes expectedStatusCodes = StatusCodes.OK;
-        Router router = new Router(HttpServer.getRoutes());
-        StatusCodes returnedCode = router.getResponse(request);
+        String expectedStatusCode = StatusCodes.OK.httpResponse + Constants.CRLF + "Allow: GET" + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
+        ResponseBuilder responseBuilder = new ResponseBuilder();
+        Router router = new Router(HttpServer.getRoutes(), responseBuilder);
+        String returnedCode = router.getResponse(request);
         System.out.print(returnedCode);
-        assertEquals(expectedStatusCodes, returnedCode);
+        assertEquals(expectedStatusCode, returnedCode);
     }
 
     @Test
     void testRouterReturns404ForInvalidRoute() throws IOException {
         HTTPRequest request = new HTTPRequest("GET", "/anything_invalid", "HTTP/1.1");
-        StatusCodes expectedStatusCodes = StatusCodes.PAGE_NOT_FOUND;
-        Router router = new Router(HttpServer.getRoutes());
-        StatusCodes returnedCode = router.getResponse(request);
+        String expectedStatusCodes = StatusCodes.PAGE_NOT_FOUND.httpResponse + Constants.CRLF + "Content-Length: 0" + Constants.CRLF;
+        ResponseBuilder responseBuilder = new ResponseBuilder();
+        Router router = new Router(HttpServer.getRoutes(), responseBuilder);
+        String returnedCode = router.getResponse(request);
         System.out.print(returnedCode);
-        assertEquals(expectedStatusCodes, returnedCode);
+        assertEquals(expectedStatusCodes.toString(), returnedCode);
     }
 
     @Test
     void testRouterReturns405ForInvalidMethod() throws IOException {
         HTTPRequest request = new HTTPRequest("GET", "/head_request", "HTTP/1.1");
-        StatusCodes expectedStatusCodes = StatusCodes.PAGE_NOT_FOUND;
-        Router router = new Router(HttpServer.getRoutes());
-        StatusCodes returnedCode = router.getResponse(request);
+        String expectedStatusCodes = StatusCodes.NOT_ACCEPTABLE.httpResponse + Constants.CRLF + "Allow: HEAD, OPTIONS" + Constants.CRLF +  "Content-Length: 0" + Constants.CRLF;;
+        ResponseBuilder responseBuilder = new ResponseBuilder();
+        Router router = new Router(HttpServer.getRoutes(), responseBuilder);
+        String returnedCode = router.getResponse(request);
         System.out.print(returnedCode);
         assertEquals(expectedStatusCodes, returnedCode);
     }


### PR DESCRIPTION
Story: 
Method Not Allowed Feature: Returns `405 Method Not Allowed` response when the client requests a non-permitted method of an existing resource. 


Changes:
-New class `ResponseBuilder` which builds HTTP responses when given a `StatusCode` and a `List` of allowed `Enum Methods`
-Added response `NOT_ACCEPTABLE` to `StatusCodes` enum
-Test `testRouterReturns405ForInvalidMethod()`


Changes in many files due to need to pass `ResponseBuilder` to `Router`
